### PR TITLE
workaround for timezone issue

### DIFF
--- a/munin/run.sh
+++ b/munin/run.sh
@@ -3,6 +3,8 @@
 # timezone settings
 TZ=${TZ:="Europe/Paris"}
 echo $TZ > /etc/timezone
+# workaround https://bugs.launchpad.net/ubuntu/+source/tzdata/+bug/1554806
+rm /etc/localtime
 dpkg-reconfigure -f noninteractive tzdata
 
 # change cron setting for updates


### PR DESCRIPTION
the TZ environment variable has no effect due to this change:
https://bugs.launchpad.net/ubuntu/+source/tzdata/+bug/1554806