### PR TITLE
fixed grep matching too many entries in run.sh

### DIFF
--- a/munin/run.sh
+++ b/munin/run.sh
@@ -77,7 +77,7 @@ for NODE in $NODES
 do
     NAME=`echo $NODE | cut -d ':' -f1`
     HOST=`echo $NODE | cut -d ':' -f2`
-    grep -q $HOST /etc/munin/munin.conf || cat << EOF >> /etc/munin/munin.conf
+    grep -q "${HOST}$" /etc/munin/munin.conf || cat << EOF >> /etc/munin/munin.conf
 [$NAME]
     address $HOST
     use_node_name yes


### PR DESCRIPTION
Fix for issue 29. The addition of NODES to munin.conf misses some because the grep for IP addresses can sometimes match multiple entries.